### PR TITLE
Improve booking progress UI and accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ e2e/artifacts/
 e2e/artifacts-out/
 e2e/test-results/
 e2e/playwright-report/
+e2e/node_modules/

--- a/Frontend/shadcn-ui/index.html
+++ b/Frontend/shadcn-ui/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="dark light" />
   <link rel="icon" href="https://public-frontend-cos.metadl.com/mgx/img/favicon.png" type="image/png">
   <title>Deinis Barber Club · Reserva tu cita</title>
   <meta name="description" content="Barbería profesional con estilo urbano. Reserva tu cita de forma rápida y sencilla." />

--- a/Frontend/shadcn-ui/src/components/BookingLayout.tsx
+++ b/Frontend/shadcn-ui/src/components/BookingLayout.tsx
@@ -5,16 +5,18 @@ interface BookingLayoutProps {
   steps: BookingStep[];
   title: string;
   subtitle?: string;
+  summary?: string;
   children: ReactNode;
 }
 
-export function BookingLayout({ steps, title, subtitle, children }: BookingLayoutProps) {
+export function BookingLayout({ steps, title, subtitle, summary, children }: BookingLayoutProps) {
   return (
     <div className="mx-auto max-w-4xl p-6 text-white space-y-6">
       <BookingSteps steps={steps} />
-      <div className="text-center">
+      <div className="text-center space-y-1">
         <h1 className="text-3xl font-bold mb-2">{title}</h1>
         {subtitle && <p className="text-neutral-400">{subtitle}</p>}
+        {summary && <p className="text-sm text-neutral-300" aria-live="polite">{summary}</p>}
       </div>
       {children}
     </div>

--- a/Frontend/shadcn-ui/src/components/BookingSteps.tsx
+++ b/Frontend/shadcn-ui/src/components/BookingSteps.tsx
@@ -8,21 +8,37 @@ export type BookingStep = {
 };
 
 export function BookingSteps({ steps }: { steps: BookingStep[] }) {
+  const activeIdx = steps.findIndex((s) => s.active);
+  const progress = ((activeIdx >= 0 ? activeIdx + 1 : 0) / steps.length) * 100;
+
   return (
-    <div className="flex items-center gap-3 text-sm mb-2">
-      {steps.map((s, i) => (
-        <div key={s.key} className="flex items-center gap-3">
-          <div
-            className={cn(
-              'px-2 py-1 rounded border',
-              s.active ? 'border-[#00D4AA] text-[#00D4AA]' : s.done ? 'border-neutral-600 text-neutral-300' : 'border-neutral-800 text-neutral-500'
-            )}
-          >
-            {s.label}
+    <div className="mb-4" aria-label="Progreso de reserva">
+      <div className="h-1 bg-neutral-800 rounded">
+        <div
+          className="h-full bg-[#00D4AA] rounded transition-all"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <div className="flex items-center gap-3 text-sm mt-2" role="list">
+        {steps.map((s, i) => (
+          <div key={s.key} className="flex items-center gap-3" role="listitem">
+            <div
+              className={cn(
+                'px-2 py-1 rounded border',
+                s.active
+                  ? 'border-[#00D4AA] text-[#00D4AA]'
+                  : s.done
+                  ? 'border-neutral-600 text-neutral-300'
+                  : 'border-neutral-800 text-neutral-500'
+              )}
+              aria-current={s.active ? 'step' : undefined}
+            >
+              <span className="font-medium mr-1">{i + 1}.</span> {s.label}
+            </div>
+            {i < steps.length - 1 && <div className="w-6 h-px bg-neutral-700" />}
           </div>
-          {i < steps.length - 1 && <div className="w-6 h-px bg-neutral-700" />}
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }

--- a/Frontend/shadcn-ui/src/components/Catch.tsx
+++ b/Frontend/shadcn-ui/src/components/Catch.tsx
@@ -5,15 +5,19 @@ export function Catch(props: { fallback: React.ReactNode; children: React.ReactN
 }
 
 class CatchBoundary extends React.Component<{ fallback: React.ReactNode; children: React.ReactNode }, { hasError: boolean }> {
-  constructor(props: any) {
+  constructor(props: { fallback: React.ReactNode; children: React.ReactNode }) {
     super(props);
     this.state = { hasError: false };
   }
-  static getDerivedStateFromError(_error: any) { return { hasError: true }; }
-  componentDidCatch(error: any, info: any) { try { console.error('CatchBoundary', error, info); } catch {} }
+  static getDerivedStateFromError(_error: unknown) {
+    return { hasError: true };
+  }
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    console.error('CatchBoundary', error, info);
+  }
   render() {
-    if (this.state.hasError) return this.props.fallback as any;
-    return this.props.children as any;
+    if (this.state.hasError) return this.props.fallback;
+    return this.props.children;
   }
 }
 

--- a/Frontend/shadcn-ui/src/components/ErrorBoundary.tsx
+++ b/Frontend/shadcn-ui/src/components/ErrorBoundary.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 
 type Props = { children: React.ReactNode };
-type State = { hasError: boolean; error?: any };
+type State = { hasError: boolean; error?: unknown };
 
 export class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { hasError: false };
   }
-  static getDerivedStateFromError(error: any) { return { hasError: true, error }; }
-  componentDidCatch(error: any, info: any) { 
-    try { console.error('ErrorBoundary', error, info); } catch {}
+  static getDerivedStateFromError(error: unknown) {
+    return { hasError: true, error };
+  }
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    console.error('ErrorBoundary', error, info);
   }
   render() {
     if (this.state.hasError) {
@@ -32,6 +34,6 @@ export class ErrorBoundary extends React.Component<Props, State> {
         </div>
       );
     }
-    return this.props.children as any;
+    return this.props.children;
   }
 }

--- a/Frontend/shadcn-ui/src/components/ui/calendar.tsx
+++ b/Frontend/shadcn-ui/src/components/ui/calendar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { DayPicker } from 'react-day-picker';
 import { es as esLocale } from 'date-fns/locale';
+import type { Locale } from 'date-fns';
 
 import { cn } from '@/lib/utils';
 import { buttonVariants } from '@/components/ui/button';
@@ -9,21 +10,21 @@ import { buttonVariants } from '@/components/ui/button';
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 
 function Calendar({ className, classNames, showOutsideDays = true, locale, ...props }: CalendarProps) {
-  // Usar español con lunes como primer día
+  // Usar español con lunes como primer día.
   const loc = React.useMemo(() => {
-    const base: any = locale ?? esLocale;
-    return { ...base, options: { ...(base.options || {}), weekStartsOn: 1 } };
+    const base: Locale = locale ?? esLocale;
+    return { ...base, options: { ...(base.options || {}), weekStartsOn: 1 } } as Locale;
   }, [locale]);
 
-  // Límite de navegación: hoy .. hoy + 183 días (≈6 meses)
+  // Límite de navegación: hoy .. hoy + 183 días (≈6 meses).
   const today = React.useMemo(() => new Date(), []);
   const toMonthDefault = React.useMemo(() => {
     const d = new Date();
     d.setDate(d.getDate() + 183);
     return d;
   }, []);
-  const fromMonth = (props as any).fromMonth ?? today;
-  const toMonth = (props as any).toMonth ?? toMonthDefault;
+  const fromMonth = props.fromMonth ?? today;
+  const toMonth = props.toMonth ?? toMonthDefault;
 
   return (
     <DayPicker
@@ -49,7 +50,7 @@ function Calendar({ className, classNames, showOutsideDays = true, locale, ...pr
         head_cell: 'text-muted-foreground h-8 text-[0.72rem] uppercase tracking-wide text-center',
         row: '',
         cell: 'p-0 text-center align-middle',
-        // Celda ligera + botón de día centrado para no romper columnas
+        // Celda ligera y botón de día centrado para no romper columnas.
         day: 'p-0 text-center align-middle',
         day_button: cn(buttonVariants({ variant: 'ghost' }), 'h-9 w-9 p-0 font-normal aria-selected:opacity-100 inline-flex items-center justify-center mx-auto'),
         day_range_end: 'day-range-end',

--- a/Frontend/shadcn-ui/src/pages/Debug.tsx
+++ b/Frontend/shadcn-ui/src/pages/Debug.tsx
@@ -14,13 +14,13 @@ const mask = (s?: string) => {
 };
 
 const Debug = () => {
-  const BASE = (import.meta as any).env.VITE_API_BASE_URL || 'http://127.0.0.1:8776';
+  const BASE = import.meta.env.VITE_API_BASE_URL || 'http://127.0.0.1:8776';
   const navigate = useNavigate();
-  const KEY = (import.meta as any).env.VITE_API_KEY as string | undefined;
-  const [health, setHealth] = useState<any>(null);
-  const [ready, setReady] = useState<any>(null);
-  const [services, setServices] = useState<any[]>([]);
-  const [pros, setPros] = useState<any[]>([]);
+  const KEY = import.meta.env.VITE_API_KEY as string | undefined;
+  const [health, setHealth] = useState<unknown>(null);
+  const [ready, setReady] = useState<unknown>(null);
+  const [services, setServices] = useState<unknown[]>([]);
+  const [pros, setPros] = useState<unknown[]>([]);
   const [days, setDays] = useState<string[]>([]);
   const [slots, setSlots] = useState<string[]>([]);
   const [date, setDate] = useState<string>('');
@@ -31,10 +31,10 @@ const Debug = () => {
 
   useEffect(() => {
     (async () => {
-      try { setHealth(await fetch(BASE + '/health').then(r => r.json())); } catch {}
-      try { setReady(await fetch(BASE + '/ready').then(r => r.json())); } catch {}
-      try { setServices(await api.getServices()); } catch {}
-      try { setPros(await api.getProfessionals()); } catch {}
+      try { setHealth(await fetch(BASE + '/health').then(r => r.json())); } catch { /* noop */ }
+      try { setReady(await fetch(BASE + '/ready').then(r => r.json())); } catch { /* noop */ }
+      try { setServices(await api.getServices()); } catch { /* noop */ }
+      try { setPros(await api.getProfessionals()); } catch { /* noop */ }
     })();
   }, [BASE]);
 

--- a/Frontend/shadcn-ui/src/pages/book/Confirm.tsx
+++ b/Frontend/shadcn-ui/src/pages/book/Confirm.tsx
@@ -21,8 +21,16 @@ const BookConfirm = () => {
 
   useEffect(() => {
     (async () => {
-      try { setServices(await api.getServices()); } catch {}
-      try { setPros(await api.getProfessionals()); } catch {}
+      try {
+        setServices(await api.getServices());
+      } catch {
+        /* noop */
+      }
+      try {
+        setPros(await api.getProfessionals());
+      } catch {
+        /* noop */
+      }
     })();
   }, []);
 

--- a/Frontend/shadcn-ui/src/pages/book/Service.tsx
+++ b/Frontend/shadcn-ui/src/pages/book/Service.tsx
@@ -68,10 +68,10 @@ const Service = () => {
       </BookingLayout>
     );
 
-  const onSelect = (id: string) => {
-    setService(id);
-    // Pasamos el servicio en la URL para evitar cualquier condición de carrera del store
-    navigate(`/book/date?service=${encodeURIComponent(id)}`);
+  const onSelect = (svc: Svc) => {
+    setService(svc.id, svc.name);
+    // Pasamos el servicio en la URL para evitar cualquier condición de carrera del store.
+    navigate(`/book/date?service=${encodeURIComponent(svc.id)}`);
   };
 
   return (
@@ -93,7 +93,12 @@ const Service = () => {
                   <span>Precio: {s.price_eur} €</span>
                 </div>
               </div>
-              <Button onClick={() => onSelect(s.id)} className="w-full" size="lg">
+              <Button
+                onClick={() => onSelect(s)}
+                className="w-full"
+                size="lg"
+                aria-label={`Seleccionar servicio ${s.name}`}
+              >
                 Seleccionar
               </Button>
             </CardContent>

--- a/Frontend/shadcn-ui/src/store/booking.ts
+++ b/Frontend/shadcn-ui/src/store/booking.ts
@@ -2,10 +2,11 @@ import { create } from 'zustand';
 
 type BookingState = {
   serviceId?: string;
+  serviceName?: string; // Nombre descriptivo del servicio.
   professionalId?: string | null;
   date?: string; // YYYY-MM-DD
   slotStart?: string; // ISO string
-  setService: (serviceId: string) => void;
+  setService: (serviceId: string, serviceName?: string) => void;
   setProfessional: (proId: string | null) => void;
   setDate: (date: string) => void;
   setSlot: (isoStart: string) => void;
@@ -14,13 +15,16 @@ type BookingState = {
 
 export const useBooking = create<BookingState>((set) => ({
   serviceId: undefined,
+  serviceName: undefined,
   professionalId: null,
   date: undefined,
   slotStart: undefined,
-  setService: (serviceId) => set({ serviceId, professionalId: null, date: undefined, slotStart: undefined }),
+  setService: (serviceId, serviceName) =>
+    set({ serviceId, serviceName, professionalId: null, date: undefined, slotStart: undefined }),
   setProfessional: (professionalId) => set({ professionalId }),
   setDate: (date) => set({ date, slotStart: undefined }),
   setSlot: (isoStart) => set({ slotStart: isoStart }),
-  reset: () => set({ serviceId: undefined, professionalId: null, date: undefined, slotStart: undefined }),
+  reset: () =>
+    set({ serviceId: undefined, serviceName: undefined, professionalId: null, date: undefined, slotStart: undefined }),
 }));
 


### PR DESCRIPTION
## Summary
- add progress bar and numbered steps to booking flow
- show step summary and service info during booking
- enhance accessibility with labels and aria attributes
- clean up error boundaries and utilities for lint compliance
- ignore e2e node_modules directory
- refine booking code comments and remove unused GCal toggle
- display human-friendly service name in booking summary

## Testing
- `pnpm lint`
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c5687de2288326938c76d3bb30d2d8