### PR TITLE
Improve booking service page styling and loading indicators

### DIFF
--- a/Frontend/shadcn-ui/src/App.tsx
+++ b/Frontend/shadcn-ui/src/App.tsx
@@ -9,8 +9,11 @@ const BookService = lazy(() => import('@/pages/book/Service'));
 import BookDate from '@/pages/book/Date';
 const BookDetails = lazy(() => import('@/pages/book/Details'));
 const BookConfirm = lazy(() => import('@/pages/book/Confirm'));
+import Loading from '@/components/Loading';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
-const DEBUG = String(import.meta.env.VITE_ENABLE_DEBUG ?? '0') === '1' || String(import.meta.env.VITE_ENABLE_DEBUG ?? '').toLowerCase() === 'true';
+const DEBUG =
+  String(import.meta.env.VITE_ENABLE_DEBUG ?? '0') === '1' ||
+  String(import.meta.env.VITE_ENABLE_DEBUG ?? '').toLowerCase() === 'true';
 const DebugPage = lazy(() => import('./pages/Debug'));
 
 const queryClient = new QueryClient();
@@ -25,15 +28,36 @@ const App = () => (
                     <Route path="/" element={<Index />} />
 
                     {/* Flujo de reservas. */}
-                    <Route path="/book/service" element={<Suspense fallback={<div style={{ padding: 16 }}>Cargando servicios…</div>}><BookService /></Suspense>} />
+                    <Route
+                        path="/book/service"
+                        element={
+                            <Suspense fallback={<Loading />}>
+                                <BookService />
+                            </Suspense>
+                        }
+                    />
                     <Route path="/book/date" element={<BookDate />} />
                     {/** Ruta /book/time eliminada: flujo es Service -> Date -> Confirm */}
-                    <Route path="/book/details" element={<Suspense fallback={<div style={{ padding: 16 }}>Cargando…</div>}><BookDetails /></Suspense>} />
-                    <Route path="/book/confirm" element={<Suspense fallback={<div style={{ padding: 16 }}>Cargando confirmación…</div>}><BookConfirm /></Suspense>} />
+                    <Route
+                        path="/book/details"
+                        element={
+                            <Suspense fallback={<Loading />}>
+                                <BookDetails />
+                            </Suspense>
+                        }
+                    />
+                    <Route
+                        path="/book/confirm"
+                        element={
+                            <Suspense fallback={<Loading />}>
+                                <BookConfirm />
+                            </Suspense>
+                        }
+                    />
                     <Route
                         path="/debug"
                         element={
-                            <Suspense fallback={<div style={{ padding: 16 }}>Cargando debug…</div>}>
+                            <Suspense fallback={<Loading />}>
                                 <DebugPage />
                             </Suspense>
                         }

--- a/Frontend/shadcn-ui/src/components/BookingSteps.tsx
+++ b/Frontend/shadcn-ui/src/components/BookingSteps.tsx
@@ -1,39 +1,6 @@
-import { useLocation, useNavigate } from 'react-router-dom';
-import { Check } from 'lucide-react';
-import { useBooking } from '@/store/booking';
+import { cn } from '@/lib/utils';
 
-export type Step = 'service' | 'date' | 'confirm';
 export type BookingStep = { key: string; label: string; active?: boolean; done?: boolean };
-
-export function BookingSteps({ steps }: { steps?: BookingStep[] }) {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const { serviceId, date, slotStart } = useBooking((s) => ({ serviceId: s.serviceId, date: s.date, slotStart: s.slotStart }));
-
-  const routeToStep = (path: string): Step => {
-    if (path.startsWith('/book/confirm')) return 'confirm';
-    if (path.startsWith('/book/date')) return 'date';
-    return 'service';
-  };
-  const current: Step = routeToStep(location.pathname);
-  const order: Step[] = ['service', 'date', 'confirm'];
-  const completed = (k: Step) => order.indexOf(k) < order.indexOf(current);
-  const canGo = (k: Step): boolean => {
-    if (k === 'service') return true;
-    if (k === 'date') return !!serviceId;
-    if (k === 'confirm') return !!serviceId && !!(slotStart || date);
-    return false;
-  };
-  const go = (k: Step) => {
-    const map: Record<Step, string> = { service: '/book/service', date: '/book/date', confirm: '/book/confirm' };
-    navigate(map[k]);
-  };
-
-  const items: { key: Step; label: string }[] = [
-    { key: 'service', label: 'Servicio' },
-    { key: 'date', label: 'Fecha y hora' },
-    { key: 'confirm', label: 'Confirmar' },
-  ];
 
 export function BookingSteps({ steps }: { steps: BookingStep[] }) {
   const activeIdx = steps.findIndex((s) => s.active);
@@ -70,3 +37,5 @@ export function BookingSteps({ steps }: { steps: BookingStep[] }) {
     </div>
   );
 }
+
+export default BookingSteps;

--- a/Frontend/shadcn-ui/src/components/Loading.tsx
+++ b/Frontend/shadcn-ui/src/components/Loading.tsx
@@ -1,0 +1,10 @@
+import { Loader2 } from 'lucide-react';
+
+const Loading = () => (
+  <div className="flex items-center justify-center p-16" aria-label="Cargando">
+    <Loader2 className="h-8 w-8 animate-spin text-emerald-400" />
+  </div>
+);
+
+export default Loading;
+

--- a/Frontend/shadcn-ui/src/lib/api.ts
+++ b/Frontend/shadcn-ui/src/lib/api.ts
@@ -1,5 +1,5 @@
 // Base de API robusto: si la env está vacía (""), usa fallback
-const _rawBase = String((import.meta as any).env?.VITE_API_BASE_URL ?? '').trim();
+const _rawBase = String(import.meta.env?.VITE_API_BASE_URL ?? '').trim();
 const BASE = _rawBase || "http://127.0.0.1:8776";
 const API_KEY: string | undefined = import.meta.env.VITE_API_KEY;
 const DEBUG = /^(1|true|yes|y)$/i.test(String(import.meta.env.VITE_ENABLE_DEBUG ?? "0"));

--- a/Frontend/shadcn-ui/src/pages/NotFound.tsx
+++ b/Frontend/shadcn-ui/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button';
 import React, { Suspense, lazy } from 'react';
+import Loading from '@/components/Loading';
 
 const DebugPage = lazy(() => import('./Debug'));
 
@@ -11,7 +12,7 @@ export default function NotFoundPage() {
     const s = (loc.pathname || '') + (loc.search || '') + (loc.hash || '');
     if (/debug/i.test(s)) {
       return (
-        <Suspense fallback={<div style={{ padding: 16 }}>Cargando debug…</div>}>
+        <Suspense fallback={<Loading />}>
           <DebugPage />
         </Suspense>
       );

--- a/Frontend/shadcn-ui/src/pages/book/Service.tsx
+++ b/Frontend/shadcn-ui/src/pages/book/Service.tsx
@@ -9,8 +9,6 @@ import { ServiceCard } from '@/components/book/ServiceCard';
 import { Scissors, Palette, Sparkles, LucideIcon, Crown, Zap } from 'lucide-react';
 import { BookingSteps } from '@/components/BookingSteps';
 import { BookingLayout } from '@/components/BookingLayout';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 
 const Service = () => {
   const navigate = useNavigate();
@@ -97,31 +95,15 @@ const Service = () => {
     <BookingLayout steps={steps} title="Selecciona un servicio" subtitle="Elige el servicio que deseas reservar">
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {services.map((s) => (
-          <Card key={s.id} className="border-neutral-800 bg-neutral-900 text-white hover:bg-neutral-800 transition-colors">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-xl">{s.name}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <div className="flex items-center gap-2 text-sm text-neutral-300">
-                  <span className="w-2 h-2 bg-blue-500 rounded-full"></span>
-                  <span>Duración: {s.duration_min} minutos</span>
-                </div>
-                <div className="flex items-center gap-2 text-sm text-neutral-300">
-                  <span className="w-2 h-2 bg-green-500 rounded-full"></span>
-                  <span>Precio: {s.price_eur} €</span>
-                </div>
-              </div>
-              <Button
-                onClick={() => onSelect(s)}
-                className="w-full"
-                size="lg"
-                aria-label={`Seleccionar servicio ${s.name}`}
-              >
-                Seleccionar
-              </Button>
-            </CardContent>
-          </Card>
+          <ServiceCard
+            key={s.id}
+            title={s.name}
+            duration={`${s.duration_min} minutos`}
+            price={`${s.price_eur} €`}
+            icon={iconMap[s.id]}
+            onSelect={() => onSelect(s)}
+            attrsId={`svc-${s.id}`}
+          />
         ))}
       </div>
     </BookingLayout>


### PR DESCRIPTION
## Summary
- Style service selection page using `ServiceCard` with icons
- Show a shared spinner while lazy-loaded pages resolve
- Clean up booking steps component and remove `any` cast in API config

## Testing
- `cd Frontend/shadcn-ui && pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c57a9c520883268a765cc8df3eb936